### PR TITLE
Add AI chat interface

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'jekyll', '~> 4.2'
+
+gem 'jekyll-paginate'
+gem 'jekyll-sitemap'

--- a/README.md
+++ b/README.md
@@ -129,3 +129,8 @@ To maintain the vertical rhythm, it has been applied a **Typographic scale** as 
 
 ## License
 Released under [MIT License](license.md).
+
+## Comments
+
+博客评论使用 [Utterances](https://utteranc.es/) 存储在 GitHub Issues 中。
+若页面提示需要安装应用，请到仓库设置中安装 Utterances GitHub App。

--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ source: .
 destination: ./_site
 permalink: /:title
 paginate: 10
-paginate_path: /page:num/
+paginate_path: /blog/page:num/
 
 # Default values
 defaults:

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,11 +3,26 @@ layout: default
 ---
 <article id="post-page">
 	<h2>{%if page.header %}{{ page.header }}{% else %}{{ page.title }}{% endif %}</h2>		
-	<time datetime="{{ page.date | date_to_xmlschema }}" class="by-line">{{ page.date | date_to_string }}</time>
-	<div class="content">
+        <time datetime="{{ page.date | date_to_xmlschema }}" class="by-line">{{ page.date | date_to_string }}</time>
+        <div class="post-interactions">
+                阅读数: <span id="view-count">0</span>
+                <button id="like-btn">👍 <span id="like-count">0</span></button>
+                <button id="dislike-btn">👎 <span id="dislike-count">0</span></button>
+        </div>
+        <div class="content">
 
-		{{ content }}
-		
-	</div>
+                {{ content }}
+
+        </div>
+        <div id="comments" class="comments"></div>
+        <p class="comment-note">如评论框未显示，请在仓库中安装 Utterances 应用</p>
+        <script src="https://utteranc.es/client.js"
+                repo="mtry1/mtry1.github.io"
+                issue-term="pathname"
+                label="comment"
+                theme="github-light"
+                crossorigin="anonymous"
+                async>
+        </script>
 </article>
 

--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -1,3 +1,20 @@
 /*- Custom style -*/
 
-// -- Put custom style under this point -- //
+.post-interactions {
+  margin: 1em 0;
+  button {
+    margin-right: 0.5em;
+  }
+  span {
+    margin-right: 1em;
+  }
+}
+
+.comments {
+  margin-top: 2em;
+}
+
+.comment-note {
+  font-size: 0.9em;
+  color: #555;
+}

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,0 +1,18 @@
+---
+layout: default
+---
+<p><a href="/">返回聊天首页</a></p>
+<!-- Posts -->
+<ul id="posts">
+
+	{% for post in paginator.posts %}
+
+	  <li class="post">
+	  	<h2><a href="{% if site.baseurl == "/" %}{{ post.url }}{% else %}{{ post.url | prepend: site.baseurl }}{% endif %}">{%if post.header %}{{ post.header }}{% else %}{{ post.title }}{% endif %}</a></h2>
+      <time datetime="{{ post.date | date_to_xmlschema }}" class="by-line"> <i>{{ post.date | date_to_string }}</i> </time>
+	  	<p>{{ post.content | strip_html | truncatewords:50 }}</p>
+	  </li>
+
+    {% endfor %}
+
+</ul>

--- a/chat.js
+++ b/chat.js
@@ -1,0 +1,61 @@
+(function() {
+  const messages = document.getElementById('messages');
+  const form = document.getElementById('chat-form');
+  const input = document.getElementById('chat-input');
+  const apiKeyInput = document.getElementById('api-key');
+  const modelSelect = document.getElementById('model');
+  const temperatureInput = document.getElementById('temperature');
+
+  // Load saved settings
+  apiKeyInput.value = localStorage.getItem('apiKey') || '';
+  modelSelect.value = localStorage.getItem('model') || 'openai/gpt-3.5-turbo';
+  temperatureInput.value = localStorage.getItem('temperature') || '1';
+
+  function appendMessage(role, text) {
+    const div = document.createElement('div');
+    div.className = 'msg ' + role;
+    div.textContent = text;
+    div.addEventListener('click', function() {
+      navigator.clipboard.writeText(text);
+    });
+    messages.appendChild(div);
+    messages.scrollTop = messages.scrollHeight;
+  }
+
+  form.addEventListener('submit', function(e) {
+    e.preventDefault();
+    const userText = input.value.trim();
+    if (!userText) return;
+    appendMessage('user', userText);
+    input.value = '';
+    appendMessage('assistant', '...');
+
+    // Save settings
+    localStorage.setItem('apiKey', apiKeyInput.value);
+    localStorage.setItem('model', modelSelect.value);
+    localStorage.setItem('temperature', temperatureInput.value);
+
+    const apiKey = apiKeyInput.value;
+    fetch('https://openrouter.ai/api/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': apiKey ? 'Bearer ' + apiKey : ''
+      },
+      body: JSON.stringify({
+        model: modelSelect.value,
+        messages: [
+          { role: 'user', content: userText }
+        ],
+        temperature: parseFloat(temperatureInput.value)
+      })
+    })
+    .then(res => res.json())
+    .then(data => {
+      messages.lastChild.textContent = data.choices && data.choices[0].message.content || '出错了';
+    })
+    .catch(() => {
+      messages.lastChild.textContent = '请求失败';
+    });
+  });
+})();

--- a/index.html
+++ b/index.html
@@ -1,17 +1,33 @@
----
-layout: default
----
-<!-- Posts -->
-<ul id="posts">
-
-	{% for post in paginator.posts %}
-
-	  <li class="post">
-	  	<h2><a href="{% if site.baseurl == "/" %}{{ post.url }}{% else %}{{ post.url | prepend: site.baseurl }}{% endif %}">{%if post.header %}{{ post.header }}{% else %}{{ post.title }}{% endif %}</a></h2>
-      <time datetime="{{ post.date | date_to_xmlschema }}" class="by-line"> <i>{{ post.date | date_to_string }}</i> </time>
-	  	<p>{{ post.content | strip_html | truncatewords:50 }}</p>
-	  </li>
-
-    {% endfor %}
-
-</ul>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AI Chat</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <nav>
+    <a href="/blog/">旧博客入口</a>
+  </nav>
+  <main id="chat-container">
+    <div id="messages" class="messages"></div>
+    <form id="chat-form">
+      <input type="text" id="chat-input" placeholder="说点什么..." autocomplete="off" required>
+      <button type="submit">发送</button>
+    </form>
+    <details id="settings">
+      <summary>设置</summary>
+      <label>API Key: <input type="text" id="api-key" placeholder="可选"></label>
+      <label>模型:
+        <select id="model">
+          <option value="openai/gpt-3.5-turbo">gpt-3.5-turbo</option>
+          <option value="openai/gpt-4-turbo">gpt-4-turbo</option>
+        </select>
+      </label>
+      <label>温度: <input type="number" id="temperature" value="1" min="0" max="2" step="0.1"></label>
+    </details>
+  </main>
+  <script src="chat.js"></script>
+</body>
+</html>

--- a/js/main.js
+++ b/js/main.js
@@ -39,3 +39,65 @@ function menuClick() {
 }
 
 menuClick();
+
+document.addEventListener('DOMContentLoaded', function() {
+    var path = location.pathname.replace(/\//g, '_');
+    var base = 'https://api.countapi.xyz';
+
+    // Views
+    fetch(base + '/hit/mtry1-github-io/views' + path)
+        .then(function(res) { return res.json(); })
+        .then(function(data) {
+            var viewSpan = document.getElementById('view-count');
+            if (viewSpan) {
+                viewSpan.textContent = data.value;
+            }
+        });
+
+    // Likes
+    var likeCount = document.getElementById('like-count');
+    fetch(base + '/get/mtry1-github-io/likes' + path)
+        .then(function(res) { return res.json(); })
+        .then(function(data) {
+            if (likeCount) {
+                likeCount.textContent = data.value || 0;
+            }
+        });
+
+    var likeBtn = document.getElementById('like-btn');
+    if (likeBtn) {
+        likeBtn.addEventListener('click', function() {
+            fetch(base + '/hit/mtry1-github-io/likes' + path)
+                .then(function(res) { return res.json(); })
+                .then(function(data) {
+                    if (likeCount) {
+                        likeCount.textContent = data.value;
+                    }
+                });
+        });
+    }
+
+    // Dislikes
+    var dislikeCount = document.getElementById('dislike-count');
+    fetch(base + '/get/mtry1-github-io/dislikes' + path)
+        .then(function(res) { return res.json(); })
+        .then(function(data) {
+            if (dislikeCount) {
+                dislikeCount.textContent = data.value || 0;
+            }
+        });
+
+    var dislikeBtn = document.getElementById('dislike-btn');
+    if (dislikeBtn) {
+        dislikeBtn.addEventListener('click', function() {
+            fetch(base + '/hit/mtry1-github-io/dislikes' + path)
+                .then(function(res) { return res.json(); })
+                .then(function(data) {
+                    if (dislikeCount) {
+                        dislikeCount.textContent = data.value;
+                    }
+                });
+        });
+    }
+});
+

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,22 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+nav {
+  background: #333;
+  padding: 0.5em;
+}
+nav a { color: #fff; text-decoration: none; }
+#chat-container { flex: 1; display: flex; flex-direction: column; padding: 1em; }
+.messages { flex: 1; overflow-y: auto; margin-bottom: 1em; }
+.msg { padding: 0.5em; margin-bottom: 0.5em; border-radius: 4px; }
+.msg.user { background: #e0f7fa; align-self: flex-end; }
+.msg.assistant { background: #f1f8e9; }
+form { display: flex; }
+#chat-input { flex: 1; padding: 0.5em; }
+button { padding: 0.5em; }
+#settings { margin-top: 1em; }


### PR DESCRIPTION
## Summary
- relocate old blog to `/blog` and update pagination path
- create `index.html` with AI chat UI and settings panel
- implement `chat.js` to call OpenRouter API and store settings in localStorage
- add view/like/dislike counts and comments on posts
- document Utterances setup for comments

## Testing
- ❌ `bundle exec jekyll build` (failed: bundler: command not found: jekyll)

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_686e5927e2cc832395949f8f11514de0